### PR TITLE
Update log4j core dependency version to address a security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <aws.sdk.version>1.11.368</aws.sdk.version>
-        <log4j.version>2.11.0</log4j.version>
+        <log4j.version>2.13.2</log4j.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Security Vulnerability for log4j-core versions < 2.13.2: Improper validation of certificate with host mismatch in Apache Log4j SMTP appender. This could allow an SMTPS connection to be intercepted by a man-in-the-middle attack which could leak any log messages sent through that appender.