### PR TITLE
Truncate large messages

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -87,3 +87,7 @@ Example with all possible configurations:
 
 When `largeMessagesEnabled` is true, messages larger than `maxMessageBytes` will be split into multiple SQS messages and placed on a FIFO queue with the same group ID value (the uuid) so they are guaranteed to be processed in order. The SQS messages will need to be accumulated so the log message can be reconstructed.
 The message format looks like this: `currentPart=1|totalParts=5|uuid=8744fe2c-cbea-4e49-8b81-0d7076899a48|message="{\"timeMillis\":1647825592778,\"thread\":\"[MuleRuntime].uber.09: [sqs-test].logFilesFlow.CPU_LITE @5d97440f\",\"level\":\"INFO\",\"loggerName\":\"com.avioconsulting.api\",\"message\":{\"timestamp\":\"2022-03-21T01:19:52.776Z\",\"appName\":\"sqs-test\",\"appVersion\":\"1.0.0\",\"correlationId\":\"0295a030-a8b5-11ec-95cb-f01898a624f3\",\"payload\":\"{\\n  \\\"filePath\\\": \\\"/docs/samplePayload.json\\\"\\n}\"},\"endOfBatch\":true,\"loggerFqcn\":\"org.apache.logging.log4j.spi.AbstractLogger\",\"contextMap\":{\"correlationId\":\"0295a030-a8b5-11ec-95cb-f01898a624f3\",\"processorPath\":\"logFilesFlow/processors/0/processors/0\"},\"threadId\":58,\"threadPriority\":5,\"timestamp\":\"2022-03-20T20:19:52.778-0500\",\"deployedAppName\":\"${sys:domain}\"}"`
+
+Special Event Handling
+================
+When an event message is larger than `maxMessageBytes`, it will be truncated to `maxMessageBytes` bytes before it is sent to SQS. If `largeMessagesEnabled` is true, the message will be split rather than truncated.

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <aws.sdk.version>1.12.181</aws.sdk.version>
         <log4j.version>2.17.2</log4j.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.2</junit.version>
         <GPG_PASSPHRASE>something</GPG_PASSPHRASE>
         <nexus.url>https://oss.sonatype.org</nexus.url>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <aws.sdk.version>1.12.181</aws.sdk.version>
         <log4j.version>2.17.2</log4j.version>
+        <junit.version>4.12</junit.version>
         <GPG_PASSPHRASE>something</GPG_PASSPHRASE>
         <nexus.url>https://oss.sonatype.org</nexus.url>
     </properties>
@@ -76,6 +77,12 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/test/java/com/avioconsulting/log4j/sqs/TestSqsManager.java
+++ b/src/test/java/com/avioconsulting/log4j/sqs/TestSqsManager.java
@@ -1,0 +1,36 @@
+package com.avioconsulting.log4j.sqs;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSqsManager {
+
+    @Test
+    public void truncateRegularMessageTest() {
+        String testString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+        String truncatedString = SqsManager.truncateStringByByteLength(testString, "UTF-8", 24);
+        Assert.assertEquals("Lorem ipsum dolor sit am", truncatedString);
+    }
+
+    @Test
+    public void truncate4byteMessageTest() {
+        String testString = "\uD80C\uDCA9Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod ";
+        String truncatedString = SqsManager.truncateStringByByteLength(testString, "UTF-8", 24);
+        Assert.assertEquals("\uD80C\uDCA9Lorem ipsum dolor si", truncatedString);
+    }
+
+    @Test
+    public void splitStringByByteLengthTest() {
+        String testString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+        String[] splitStrings = SqsManager.splitStringByByteLength(testString, "UTF-8", 24);
+        Assert.assertEquals(splitStrings.length, 19);
+    }
+
+    @Test
+    public void multibyteSplitStringByByteLengthTest() {
+        String testString = "\uD80C\uDCA9\uD80C\uDCA9\uD80C\uDCA9\uD80C\uDCA9\uD80C\uDCA9\uD80C\uDCA9\uD80C\uDCA9\uD80C\uDCA9\uD80C\uDCA9\uD80C\uDCA9\uD80C\uDCA9\uD80C\uDCA9";
+        String[] splitStrings = SqsManager.splitStringByByteLength(testString, "UTF-8", 24);
+        Assert.assertEquals(splitStrings.length, 2);
+    }
+
+}


### PR DESCRIPTION
Truncates messages that are larger than `maxMessageBytes`
Added a couple of unit tests for splitting and truncating messages